### PR TITLE
 ~ fix headers case sensitivity

### DIFF
--- a/src/Header.php
+++ b/src/Header.php
@@ -33,7 +33,7 @@ class Header
      */
     protected function setHeaders()
     {
-        $this->headers = getallheaders();
+        $this->headers = array_change_key_case(getallheaders(), CASE_LOWER);
     }
 
     /**


### PR DESCRIPTION
In my case, headers were capitalised, i.e `'X-Chunk-Number' => string '1'` which makes the in_array() check fail in Header->filter().

Fixed referencing this comment; https://www.php.net/manual/en/function.getallheaders.php#124775