### PR TITLE
Implemented a fix for setting a custom driver

### DIFF
--- a/src/Chunk.php
+++ b/src/Chunk.php
@@ -197,9 +197,11 @@ class Chunk
         if (in_array($this->configs['driver'], ['local', 'ftp'])) {
             $name = ucfirst($this->configs['driver']);
             $driver = "\\Wester\\ChunkUpload\\Drivers\\{$name}Driver";
+        } else {
+            $driver = $this->configs['driver'];
         }
 
-        $this->driver = new $this->configs['driver']($this);
+        $this->driver = new $driver($this);
         $this->driver->open();
 
         return $this;

--- a/src/Chunk.php
+++ b/src/Chunk.php
@@ -199,7 +199,7 @@ class Chunk
             $driver = "\\Wester\\ChunkUpload\\Drivers\\{$name}Driver";
         }
 
-        $this->driver = new $driver($this);
+        $this->driver = new $this->configs['driver']($this);
         $this->driver->open();
 
         return $this;


### PR DESCRIPTION
Currently, the package throws an error when attempting to set a custom driver, "variable $driver not found" this pull request fixes that problem and allows use of a custom driver.