### PR TITLE
Update ExtensionRule.php

### DIFF
--- a/src/Validation/Rules/ExtensionRule.php
+++ b/src/Validation/Rules/ExtensionRule.php
@@ -57,7 +57,7 @@ class ExtensionRule
                 pathinfo($this->value, PATHINFO_EXTENSION)
             );
 
-            return ! empty($extension) && in_array($extension, $extensions);
+            return ! empty($extension) && in_array(strtolower($extension), $extensions);
         }
 
         return true;


### PR DESCRIPTION
Some devices create files with uppercase/mixed case extensions (.JPG seems to be a common one) - and, on windows the file extension is not visible by default so it's difficult for users to change.